### PR TITLE
supposed to be "if not exist" test, yes?

### DIFF
--- a/wrtbwmon.sh
+++ b/wrtbwmon.sh
@@ -25,7 +25,7 @@
 #!@todo add logger
 #!@todo reference awk scripts and html templates in predictable location
 
-[ -p /tmp/wrtbwmon.pipe ] || mkfifo /tmp/wrtbwmon.pipe
+[! -p /tmp/wrtbwmon.pipe ] || mkfifo /tmp/wrtbwmon.pipe
 
 trap "rm -f /tmp/*$$.tmp; kill $$" INT
 baseDir=.


### PR DESCRIPTION
Also consider using `mknod /tmp/wrtbmon.pipe p` instead of `mkfifo`.  I encountered a router/firmware where the latter wasn't available (https://bitbucket.org/padavan/rt-n56u/issues/123/mkfifo-not-found)
